### PR TITLE
Full-Width (Hero) Blocks Prototyping

### DIFF
--- a/source/blocks.html.erb
+++ b/source/blocks.html.erb
@@ -8,7 +8,10 @@ title: Block List
 		<p>Sample content blocks with layouts and some basic styles.<br /></p>
 
 
-		<%= partial "blocks/block-hero" %>
+		<%= partial "blocks/block-hero-image" %>
+
+
+		<%= partial "blocks/block-hero-bgimage-title-subtitle" %>
 
 
 		<%= partial "blocks/block-title-subtitle" %>

--- a/source/blocks.html.erb
+++ b/source/blocks.html.erb
@@ -8,6 +8,8 @@ title: Block List
 		<p>Sample content blocks with layouts and some basic styles.<br /></p>
 
 
+		<%= partial "blocks/block-hero" %>
+
 
 		<%= partial "blocks/block-title-subtitle" %>
 		

--- a/source/blocks.html.erb
+++ b/source/blocks.html.erb
@@ -41,8 +41,6 @@ title: Block List
 		<%= partial "blocks/block-spacer" %>
 
 
-
-
 	</div> <!-- ./container -->
 
 

--- a/source/blocks/_block-hero-bgimage-title-subtitle.erb
+++ b/source/blocks/_block-hero-bgimage-title-subtitle.erb
@@ -2,11 +2,20 @@
 
 	<div class="layout">
 
-		<div class="col-12 bgimage"
+		<div class="col-12">
+				 
+			<div class="bgimage"
 					 style="background-image: url('http://placeimg.com/1200/380/tech');">
 				
-			<h1 class="center title">Hello World!</h1>
-			<p class="center subtitle">This Is a Full-Width Banner Block</p>
+				<div class="overlay block">
+
+					<h1 class="center title">Hello Hero!</h1>
+				
+					<p class="center subtitle">This Is a Full-Width Banner Block</p>
+
+				</div>
+				
+			</div>
 
 		</div>
 

--- a/source/blocks/_block-hero-bgimage-title-subtitle.erb
+++ b/source/blocks/_block-hero-bgimage-title-subtitle.erb
@@ -1,0 +1,15 @@
+<div class="block typeset hero">
+
+	<div class="layout">
+
+		<div class="col-12 bgimage"
+					 style="background-image: url('http://placeimg.com/1200/380/tech');">
+				
+			<h1 class="center title">Hello World!</h1>
+			<p class="center subtitle">This Is a Full-Width Banner Block</p>
+
+		</div>
+
+	</div>
+
+</div>

--- a/source/blocks/_block-hero-image.erb
+++ b/source/blocks/_block-hero-image.erb
@@ -1,0 +1,13 @@
+<div class="block typeset hero">
+
+	<div class="layout">
+
+		<div class="col-12">
+			
+			<img class="media" src="http://placeimg.com/1200/380/tech" alt=" "/>
+
+		</div>
+
+	</div>
+
+</div>

--- a/source/blocks/_block-hero.erb
+++ b/source/blocks/_block-hero.erb
@@ -1,4 +1,4 @@
-<div class="block">
+<div class="block typeset hero">
 
 	<div class="layout">
 

--- a/source/blocks/_block-title-subtitle-image.erb
+++ b/source/blocks/_block-title-subtitle-image.erb
@@ -1,9 +1,11 @@
-<div class="block">
+<div class="block typeset">
 
 	<div class="layout">
 
 		<div class="col-12">
 			
+			<h1 class="center title">This is The Story</h1>
+			<p class="center subtitle">And This Is A Subtitle That Really Makes It Easy To Understand</p>
 			<img class="media" src="http://placeimg.com/1200/380/tech" alt=" "/>
 
 		</div>

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -12,7 +12,7 @@
     <!-- Use title if it's in the page YAML frontmatter -->
     <title><%= current_page.data.title || "The Middleman" %></title>
 
-    <%= stylesheet_link_tag "normalize", "all", "grid", "typography" %>
+    <%= stylesheet_link_tag "normalize", "all", "grid", "blocks/hero", "typography" %>
     <%= javascript_include_tag  "all" %>
   </head>
 

--- a/source/stylesheets/_variables.scss
+++ b/source/stylesheets/_variables.scss
@@ -29,3 +29,6 @@ $quiet-type-color: #ccc;
 
 $link-color: green;
 $link-hover: darken($link-color, 12%);
+
+
+$default-overlay-color: rgba(255, 255, 255, 0.75);

--- a/source/stylesheets/blocks/hero.scss
+++ b/source/stylesheets/blocks/hero.scss
@@ -1,0 +1,29 @@
+@import "variables";
+
+// Hero Block Styling 
+// TODO: A lot of this could be put into a more general blocks.scss, such as nested block behavior.
+.container {	
+	.block.hero {
+		// Hero blocks take up the full width
+		max-width: none;
+		padding: 0;
+		width: 100%;
+		.bgimage {
+			// Basic Background Styling
+			background-position: center center;
+			background-repeat: no-repeat;
+			background-size: cover;
+			// Provide top and bottom padding for the overlay block
+			padding: 10% 0;
+			.block.overlay {
+				// This should be a variable dependant on the text color.
+				background: $default-overlay-color;
+				// Nested blocks shouldn't have additional bottom margin.
+				margin-bottom: 0;
+				h1 {
+					margin-top: 0;
+				}
+			}
+		}
+	}
+}

--- a/source/stylesheets/grid.scss
+++ b/source/stylesheets/grid.scss
@@ -67,11 +67,12 @@ img {
 } 
 
 
-// Measure, that is max width of the content area
+// Don't give the container any margin or padding so that we can easily create full-width blocks.
 .container {
   @include outer-container; 
   margin: 0 auto;
 	max-width: none;
+	// Give normal blocks a max-width set to the percentage of the screen width. Center them.
 	.block {
 		margin-left: auto;
 		margin-right: auto;
@@ -87,16 +88,6 @@ img {
 		}  
 		@include breakpoint($xxlarge) {
 			max-width: 58%;
-		}
-	}
-	.block.hero {
-		max-width: none;
-		padding: 0;
-		width: 100%;
-		.bgimage {
-			background-position: center center;
-			background-repeat: no-repeat;
-			background-size: cover;
 		}
 	}
 }

--- a/source/stylesheets/grid.scss
+++ b/source/stylesheets/grid.scss
@@ -71,23 +71,27 @@ img {
 .container {
   @include outer-container; 
   margin: 0 auto;
-  max-width: 96%;
-  
-  @include breakpoint($medium) {
+	.block {
+		margin-left: auto;
+		margin-right: auto;
+		max-width: 96%;	
+		@include breakpoint($medium) {
       max-width: 84%; 
-  }
-  
-  @include breakpoint($large) {
-    max-width: 76%;
-  }  
-  
-  @include breakpoint($xlarge) {
-    max-width: 68%;
-  }  
-
-  @include breakpoint($xxlarge) {
-    max-width: 58%;
-  }
+		}		
+		@include breakpoint($large) {
+			max-width: 76%;
+		}  		
+		@include breakpoint($xlarge) {
+			max-width: 68%;
+		}  
+		@include breakpoint($xxlarge) {
+			max-width: 58%;
+		}
+	}
+	.block.hero {
+		max-width: none;
+		width: 100%;
+	}
 }
 
 ///

--- a/source/stylesheets/grid.scss
+++ b/source/stylesheets/grid.scss
@@ -78,14 +78,14 @@ img {
 		margin-right: auto;
 		max-width: 96%;	
 		@include breakpoint($medium) {
-      max-width: 84%; 
-		}		
+			max-width: 84%;
+		}
 		@include breakpoint($large) {
 			max-width: 76%;
 		}  		
 		@include breakpoint($xlarge) {
 			max-width: 68%;
-		}  
+		}
 		@include breakpoint($xxlarge) {
 			max-width: 58%;
 		}

--- a/source/stylesheets/grid.scss
+++ b/source/stylesheets/grid.scss
@@ -71,6 +71,7 @@ img {
 .container {
   @include outer-container; 
   margin: 0 auto;
+	max-width: none;
 	.block {
 		margin-left: auto;
 		margin-right: auto;
@@ -90,7 +91,13 @@ img {
 	}
 	.block.hero {
 		max-width: none;
+		padding: 0;
 		width: 100%;
+		.bgimage {
+			background-position: center center;
+			background-repeat: no-repeat;
+			background-size: cover;
+		}
 	}
 }
 


### PR DESCRIPTION
The code will probably need some cleanup, but I think this demonstrates the way we could support full-width blocks. 

The part you probably haven't seen is my addition to the background-image hero, where I added a "nested block" for the content inside the background image block. Not sure if this block should also follow the usual `block -> layout -> col-n` scheme.

I tried to separate the "hero" specific styling into its own stylesheet under a new `blocks/` directory; I figured this would be a good thing to do for the more custom blocks in the future.
